### PR TITLE
:wrench: lifecycle for terraform to ignore_changes when user has set replicaset to 0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,4 +63,10 @@ resource "kubernetes_deployment" "service_pod" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec.0.replicas
+    ]
+  }
 }


### PR DESCRIPTION
Introduces the lifecycle block to ignore_changes to the service-pod so users can set replicaset count to 0, then spring it back up when they wish to.

Relates to support issue [6061](https://github.com/ministryofjustice/cloud-platform/issues/6061)